### PR TITLE
Store the lastid file in the users home

### DIFF
--- a/core/helpers.rb
+++ b/core/helpers.rb
@@ -25,25 +25,26 @@ module Helpers
 		Ctxt.logger.debug("uri: #{uri}")
 		return URI.escape(uri)
 	end
-	def last_id_store(job)
-		if ENV["OCRA_EXECUTABLE"]==nil
-			path=File.join(Dir.home(), ".dp2", "lastid")
-		else
-			path=File.dirname(ENV["OCRA_EXECUTABLE"])+"\\.lastid"
-		end
 
+        def last_id_file
+		if ENV["OCRA_EXECUTABLE"]==nil
+			path=File.join(Dir.home(), ".daisy-pipeline","dp2", "lastid")
+		else
+			path=File.join(ENV["APPDATA"],"DAISY Pipeline 2","dp2","lastid")
+		end
+                return path
+        end
+
+	def last_id_store(job)
+                path=last_id_file()
                 Dir.mkdir(File.dirname(path)) unless Dir.exists?(File.dirname(path))
 
 		Ctxt.logger.debug("writing id to #{path}")
 		File.open(path, 'w') {|f| f.write(job.id) }
 	end
+
 	def last_id_read
-		if ENV["OCRA_EXECUTABLE"]==nil
-			path=File.join(Dir.home(), ".dp2", "lastid")
-		else
-			path=File.dirname(ENV["OCRA_EXECUTABLE"])+"\\.lastid"
-		end
-		
+                path= last_id_file
 		id=""
 		if File.exists?(path)
 			f=File.open(path, 'r') 


### PR DESCRIPTION
As discussed in the mailing list:

This patch uses `Dir.home` and therefore assumes that you have Ruby1.9.
Don't know if we impose this on the user so far. Also it creates a `.dp2`
directory in the users home and puts the `lastid` file in there. Here we assume
that there might be more files coming, e.g. `config.yml`
